### PR TITLE
child_process.spawn does not work with npm run scripts on windows.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,5 @@ node_js:
 - "iojs-3"
 - "4"
 - "5"
+before_script: "which npm"
 script: "npm test"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,6 +21,7 @@ install:
 - node --version
 - npm --version
 - npm install
+- where npm
 
 # build
 build: off

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
-    "touch": "^1.0.0"
+    "touch": "^1.0.0",
+    "which": "^1.2.0"
   },
   "scripts": {
     "test": "npm run touch1 --verbose && node test.js",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "touch": "^1.0.0"
   },
   "scripts": {
-    "test": "npm run touch1",
+    "test": "npm run touch1 && node test.js",
     "touch1": "touch foo.txt"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "dependencies": {
-    "touch": "^1.0.0",
-    "which": "^1.2.0"
+    "touch": "^1.0.0"
   },
   "scripts": {
     "test": "npm run touch1 --verbose && node test.js",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "touch": "^1.0.0"
   },
   "scripts": {
-    "test": "npm run touch1 && node test.js",
+    "test": "npm run touch1 --verbose && node test.js",
     "touch1": "touch foo.txt"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "iswin": "0.0.2",
     "touch": "^1.0.0"
   },
   "scripts": {

--- a/test.js
+++ b/test.js
@@ -2,4 +2,5 @@ var spawn = require('child_process').spawn;
 var touch1 = spawn('npm', ['run', 'touch1'], { stdio: 'inherit' });
 touch1.on('error', function(err) {
   console.error(err);
+  process.exit(1);
 });

--- a/test.js
+++ b/test.js
@@ -1,5 +1,5 @@
 var spawn = require('child_process').spawn;
 var touch1 = spawn('npm', ['run', 'touch1'], { stdio: 'inherit' });
 touch1.on('error', function(err) {
-  console.log(err);
+  console.error(err);
 });

--- a/test.js
+++ b/test.js
@@ -1,4 +1,5 @@
 var spawn = require('child_process').spawn;
+console.log(process.env.PATH);
 var touch1 = spawn('npm', ['run', 'touch1', '--verbose'], { stdio: 'inherit' });
 touch1.on('error', function(err) {
   console.error(err);

--- a/test.js
+++ b/test.js
@@ -1,4 +1,7 @@
 var spawn = require('child_process').spawn;
+console.log('process.cwd()');
+console.log(process.cwd());
+console.log('process.env.PATH');
 console.log(process.env.PATH);
 var touch1 = spawn('npm', ['run', 'touch1', '--verbose'], { stdio: 'inherit' });
 touch1.on('error', function(err) {

--- a/test.js
+++ b/test.js
@@ -1,8 +1,21 @@
 var spawn = require('child_process').spawn;
+var which = require('which');
+
 console.log('process.cwd()');
 console.log(process.cwd());
 console.log('process.env.PATH');
 console.log(process.env.PATH);
+
+which('npm', function (error, resolvedPath) {
+  if (error) {
+    console.error('which npm: error');
+    console.error(error);
+    return;
+  }
+  console.log('which npm:');
+  console.log(resolvedPath);
+});
+
 var touch1 = spawn('npm', ['run', 'touch1', '--verbose'], { stdio: 'inherit' });
 touch1.on('error', function(err) {
   console.error(err);

--- a/test.js
+++ b/test.js
@@ -1,5 +1,5 @@
 var spawn = require('child_process').spawn;
-var touch1 = spawn('npm', ['run', 'touch1'], { stdio: 'inherit' });
+var touch1 = spawn('npm', ['run', 'touch1', '--verbose'], { stdio: 'inherit' });
 touch1.on('error', function(err) {
   console.error(err);
   process.exit(1);

--- a/test.js
+++ b/test.js
@@ -1,21 +1,8 @@
 var spawn = require('child_process').spawn;
-var which = require('which');
-
 console.log('process.cwd()');
 console.log(process.cwd());
 console.log('process.env.PATH');
 console.log(process.env.PATH);
-
-which('npm', function (error, resolvedPath) {
-  if (error) {
-    console.error('which npm: error');
-    console.error(error);
-    return;
-  }
-  console.log('which npm:');
-  console.log(resolvedPath);
-});
-
 var touch1 = spawn('npm', ['run', 'touch1', '--verbose'], { stdio: 'inherit' });
 touch1.on('error', function(err) {
   console.error(err);

--- a/test.js
+++ b/test.js
@@ -1,9 +1,11 @@
 var spawn = require('child_process').spawn;
+var iswin = require('iswin');
 console.log('process.cwd()');
 console.log(process.cwd());
 console.log('process.env.PATH');
 console.log(process.env.PATH);
-var touch1 = spawn('npm', ['run', 'touch1', '--verbose'], { stdio: 'inherit' });
+var cmd = (iswin()) ? 'npm.cmd' : 'npm';
+var touch1 = spawn(cmd, ['run', 'touch1', '--verbose'], { stdio: 'inherit' });
 touch1.on('error', function(err) {
   console.error(err);
   process.exit(1);

--- a/test.js
+++ b/test.js
@@ -1,2 +1,5 @@
 var spawn = require('child_process').spawn;
-spawn('npm', ['run', 'touch1'], { stdio: 'inherit' });
+var touch1 = spawn('npm', ['run', 'touch1'], { stdio: 'inherit' });
+touch1.on('error', function(err) {
+  console.log(err);
+});

--- a/test.js
+++ b/test.js
@@ -4,6 +4,8 @@ console.log('process.cwd()');
 console.log(process.cwd());
 console.log('process.env.PATH');
 console.log(process.env.PATH);
+console.log('process.env.PATHEXT');
+console.log(process.env.PATHEXT);
 var cmd = (iswin()) ? 'npm.cmd' : 'npm';
 var touch1 = spawn(cmd, ['run', 'touch1', '--verbose'], { stdio: 'inherit' });
 touch1.on('error', function(err) {

--- a/test.js
+++ b/test.js
@@ -1,1 +1,2 @@
-process.exit(1);
+var spawn = require('child_process').spawn;
+spawn('npm', ['run', 'touch1'], { stdio: 'inherit' });


### PR DESCRIPTION
`child_process.spawn` does not work with `npm run scripts` on windows.

```
# package.json
{
  "dependencies": {
    "touch": "^1.0.0"
  },
  "scripts": {
    "test": "npm run touch1 --verbose && node test.js",
    "touch1": "touch foo.txt"
  }
}

# test.js
var spawn = require('child_process').spawn;
var touch1 = spawn('npm', ['run', 'touch1', '--verbose'], { stdio: 'inherit' });
touch1.on('error', function(err) {
  console.error(err);
  process.exit(1);
});
```

`npm run touch1` works fine both linux and windows.

`spawn('npm', ['run', 'touch1'])` works fine on linux.
https://travis-ci.org/sanemat/node-windows-spawn-confirm/builds/89416274
But this does not work on windows.
https://ci.appveyor.com/project/sanemat/node-windows-spawn-confirm/build/1.0.2

```
{ [Error: spawn npm ENOENT]
  code: 'ENOENT',
  errno: 'ENOENT',
  syscall: 'spawn npm',
  path: 'npm' }
```

Is this nodejs issue? or npm issue?
